### PR TITLE
fix: basecamp shapeup book link

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Hellonext helps you close the user feedback loop. Comes with feedback portal, ro
 - [Intercom on Product Management](https://www.intercom.com/resources/books/intercom-product-management)
 - [An Elegant Puzzle](https://lethain.com/elegant-puzzle/) - By Will Larson.
 - [The Art of Doing Science and Engineering: Learning to Learn](https://en.wikipedia.org/wiki/The_Art_of_Doing_Science_and_Engineering) - By Richard W. Hamming.
-- [Shape Up](https://basecamp.com/shapeup/webbook) - By Ryan Singer.
+- [Shape Up](https://basecamp.com/shapeup) - By Ryan Singer.
 - [Outcomes over Output: Why Customer Behavior Is the Key Metric for Business Success](https://www.chapters.indigo.ca/en-ca/books/outcomes-over-output-why-customer/9781393721772-item.html) - By Joshua Seiden.
 - [Difficult Conversations](https://www.chapters.indigo.ca/en-ca/books/difficult-conversations-how-to-discuss/9780143118442-item.html) - By Douglas Stone.
 - [Good Strategy, Bad Strategy](https://www.barnesandnoble.com/w/good-strategy-bad-strategy-richard-rumelt/1101087922?ean=9780307886231) - By Richard Rumelt.


### PR DESCRIPTION
the old link is broken. updating new basecamp link for Shapeup book.