### PR TITLE
Add PM-Skills - Open source Product Management skills for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ Technical perspectives on product development and engineering practices.
 - [Stratechery by Ben Thompson](https://stratechery.com/) - Product and strategy insights from the industry.
 - [Mobbin](https://mobbin.design/) - Hand-picked collection of mobile app design patterns.
 - [Marketing for Engineers](https://github.com/goabstract/Marketing-for-Engineers) - A handy guide on growing marketing skills for folks with engineering backgrounds.
-- [PM-Skills](https://github.com/product-on-purpose/pm-skills) - 24 open-source PM skills for AI agents covering the Triple Diamond framework: discover, define, develop, deliver, measure, and iterate. Includes production-ready templates, workflow bundles, and comprehensive examples. Works with Claude, GitHub Copilot, Cursor, and Windsurf. Apache 2.0 licensed.
+- [PM-Skills](https://github.com/product-on-purpose/pm-skills) - 24 open-source PM skills for AI agents covering the Triple Diamond framework: discover, define, develop, deliver, measure, and iterate. Includes production-ready templates, workflow bundles, and comprehensive examples. Works with Claude Code, Claude Desktop, Claude.ai, GitHub Copilot, Cursor, and Windsurf. Apache 2.0 licensed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Technical perspectives on product development and engineering practices.
 - [Stratechery by Ben Thompson](https://stratechery.com/) - Product and strategy insights from the industry.
 - [Mobbin](https://mobbin.design/) - Hand-picked collection of mobile app design patterns.
 - [Marketing for Engineers](https://github.com/goabstract/Marketing-for-Engineers) - A handy guide on growing marketing skills for folks with engineering backgrounds.
+- [PM-Skills](https://github.com/product-on-purpose/pm-skills) - 24 open-source PM skills for AI agents covering the Triple Diamond framework: discover, define, develop, deliver, measure, and iterate. Includes production-ready templates, workflow bundles, and comprehensive examples. Works with Claude, GitHub Copilot, Cursor, and Windsurf. Apache 2.0 licensed.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adding PM-Skills to the Additional resources section - an open-source collection of 24 professional PM skills and templates for AI assistants.

## Why Add This?

- **Open Source:** Apache 2.0 licensed, completely free
- **Educational:** Teaches frameworks like JTBD, Opportunity Trees, ADRs
- **Practical:** Production-ready templates for PRDs, user stories, experiments, etc.
- **Comprehensive:** Covers full product lifecycle across Triple Diamond framework
- **Platform Agnostic:** Works with Claude, GitHub Copilot, Cursor, Windsurf

## Link

https://github.com/product-on-purpose/pm-skills

## Checklist

- [x] Follows existing format
- [x] No pay-walled content
- [x] Genuinely helpful resource
- [x] Link works correctly
- [x] Appropriate section

Thanks for maintaining this excellent resource!