### PR TITLE
Adding RoadmapSnap to the Product Roadmapping & Feedback section

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Open-source PMO governance platform for enterprise program visibility. Provides 
 | Developer | [Moises Prat](https://github.com/moisesprat) |
 | Cost | Free (open source) |
 | Platform | Web |
-| URL | <https://roadmapsnapweb.pages.dev> |
+| URL | <https://roadmapsnapweb.moisesprat.dev> |
 
 ### OKRs & Outcome Tracking
 Track team goals and outcomes, not just output. These tools help PMs maintain focus on measurable impact.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ By definition, a product manager is an individual who drives the product vision 
     - [logchimp](#logchimp)
     - [Hellonext](#hellonext)
     - [Screeb](#screeb)
+    - [RoadmapSnap](#roadmapsnap)
   - [OKRs & Outcome Tracking](#okrs--outcome-tracking)
     - [Tability](#tability)
-    - [RoadmapSnap](#roadmapsnap)
 - [Articles](#articles)
   - [Product Fundamentals & Philosophy](#product-fundamentals--philosophy)
   - [Product Development & Process](#product-development--process)
@@ -299,6 +299,16 @@ Screeb is a product-led user research platform helping product teams to build be
 | Platform  | Web                                |
 | URL       | https://screeb.app                 |
 
+#### RoadmapSnap
+
+Open-source PMO governance platform for enterprise program visibility. Provides executive KPI dashboards, cross-program dependency mapping, and risk tracking across strategic programs. No backend required — configure via a single file.
+
+| Property | Value |
+| --- | --- |
+| Developer | [Moises Prat](https://github.com/moisesprat) |
+| Cost | Free (open source) |
+| Platform | Web |
+| URL | <https://roadmapsnapweb.pages.dev> |
 
 ### OKRs & Outcome Tracking
 Track team goals and outcomes, not just output. These tools help PMs maintain focus on measurable impact.
@@ -314,17 +324,6 @@ A lightweight OKR tracking tool that helps product teams stay focused on outcome
 | Cost       | Freemium (Paid plans from $35/mo)  |
 | Platform   | Web                                |
 | URL        | https://tability.io                |
-
-#### RoadmapSnap
-
-Open-source PMO governance platform for enterprise program visibility. Provides executive KPI dashboards, cross-program dependency mapping, and risk tracking across strategic programs. No backend required — configure via a single file.
-
-| Property | Value |
-| --- | --- |
-| Developer | [Moises Prat](https://github.com/moisesprat) |
-| Cost | Free (open source) |
-| Platform | Web |
-| URL | <https://roadmapsnapweb.pages.dev> |
 
 ## Articles
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ By definition, a product manager is an individual who drives the product vision 
     - [Screeb](#screeb)
   - [OKRs & Outcome Tracking](#okrs--outcome-tracking)
     - [Tability](#tability)
+    - [RoadmapSnap](#roadmapsnap)
 - [Articles](#articles)
   - [Product Fundamentals & Philosophy](#product-fundamentals--philosophy)
   - [Product Development & Process](#product-development--process)
@@ -313,6 +314,17 @@ A lightweight OKR tracking tool that helps product teams stay focused on outcome
 | Cost       | Freemium (Paid plans from $35/mo)  |
 | Platform   | Web                                |
 | URL        | https://tability.io                |
+
+#### RoadmapSnap
+
+Open-source PMO governance platform for enterprise program visibility. Provides executive KPI dashboards, cross-program dependency mapping, and risk tracking across strategic programs. No backend required — configure via a single file.
+
+| Property | Value |
+| --- | --- |
+| Developer | [Moises Prat](https://github.com/moisesprat) |
+| Cost | Free (open source) |
+| Platform | Web |
+| URL | <https://roadmapsnapweb.pages.dev> |
 
 ## Articles
 


### PR DESCRIPTION
## Add RoadmapSnap

Adding RoadmapSnap to the Product Roadmapping & Feedback section.

**RoadmapSnap** is an open-source PMO governance platform for enterprise 
program visibility. It provides executive KPI dashboards, cross-program 
dependency mapping, and risk tracking — with no backend or database required.

- Live demo: https://roadmapsnapweb.moisesprat.dev
- GitHub: https://github.com/moises-prat-epm/RoadmapSnap
- Author: https://moisesprat.dev
- License: MIT
- Cost: Free (open source)

Checklist:
- [x] Link is working
- [x] Spelling and grammar checked
- [x] Added to correct section (Product Roadmapping & Feedback)
- [x] Added to Contents table
- [x] Alphabetical order maintained
- [x] Follows existing entry format (description + properties table)