### PR TITLE
Add Product Onboarding to Additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ Technical perspectives on product development and engineering practices.
 - [Stratechery by Ben Thompson](https://stratechery.com/) - Product and strategy insights from the industry.
 - [Mobbin](https://mobbin.design/) - Hand-picked collection of mobile app design patterns.
 - [Marketing for Engineers](https://github.com/goabstract/Marketing-for-Engineers) - A handy guide on growing marketing skills for folks with engineering backgrounds.
+- [Product Onboarding](https://productonboarding.com) - A free, curated gallery of user onboarding examples from leading SaaS products (Figma, Notion, Stripe, Linear, Slack, and more), categorized by pattern and by company.
 
 ## License
 


### PR DESCRIPTION
Adding [Product Onboarding](https://productonboarding.com) to the Additional resources section.

It's a free, curated gallery of user onboarding examples from leading SaaS products (Figma, Notion, Stripe, Linear, Slack, Intercom, Canva, Loom, Airtable, Webflow, and many more), categorized by pattern (welcome tours, tooltips, checklists, empty states, growth loops) and by company. PMs working on activation and onboarding flows reference it as a shortcut to real examples.

Free to browse, no login required. Built by the team at [Frigade](https://frigade.com).