### PR TITLE
Add PM Mapped to Additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ Technical perspectives on product development and engineering practices.
 - [Stratechery by Ben Thompson](https://stratechery.com/) - Product and strategy insights from the industry.
 - [Mobbin](https://mobbin.design/) - Hand-picked collection of mobile app design patterns.
 - [Marketing for Engineers](https://github.com/goabstract/Marketing-for-Engineers) - A handy guide on growing marketing skills for folks with engineering backgrounds.
+- [PM Mapped](https://pmmapped.com/) - A visual map of 156 product management frameworks across 6 modules, with free interactive tools (RICE, North Star, Four Big Risks) and plain-English guides.
 
 ## License
 


### PR DESCRIPTION
Hi. Adding PM Mapped (https://pmmapped.com) — a free, curated map of 156 product management frameworks across 6 modules, with interactive tools (RICE calculator, North Star metric builder, Four Big Risks assessment) and plain-English guides. It felt like a better fit under Additional resources than Tools. No signup needed. Thanks for maintaining this list!