### PR TITLE
Add ProjectBook to Product Roadmapping & Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ By definition, a product manager is an individual who drives the product vision 
     - [logchimp](#logchimp)
     - [Hellonext](#hellonext)
     - [Screeb](#screeb)
+    - [ProjectBook](#projectbook)
   - [OKRs & Outcome Tracking](#okrs--outcome-tracking)
     - [Tability](#tability)
 - [Articles](#articles)
@@ -297,6 +298,17 @@ Screeb is a product-led user research platform helping product teams to build be
 | Cost      | Freemium (_start $0-39/month_)     |
 | Platform  | Web                                |
 | URL       | https://screeb.app                 |
+
+#### ProjectBook
+
+ProjectBook is an open-source design-thinking workspace that enforces traceability from user insight to shipped outcome, linking stories, problems, ideas, tasks, and feedback so every task traces back to the research that justified it. Self-hostable via Docker Compose.
+
+| Property  | Value                                                        |
+|-----------|--------------------------------------------------------------|
+| Developer | [ProjectBook](https://github.com/MrEthical07/projectbook)    |
+| Cost      | Free (Open source, Apache-2.0)                               |
+| Platform  | Web, Self-hosted                                             |
+| URL       | https://projectbook.dev                                      |
 
 
 ### OKRs & Outcome Tracking


### PR DESCRIPTION
Adds **ProjectBook** to *Tools → Product Roadmapping & Feedback*.

ProjectBook is an open-source (Apache-2.0) design-thinking workspace built around traceability: stories, problems, ideas, tasks, and feedback are explicitly linked, so every task can be traced back to the user research that justified it. It can be self-hosted with Docker Compose or used at projectbook.dev.

It sits in this section because its core use case is turning user feedback and research into a prioritized, defensible roadmap — adjacent to logchimp and Hellonext, but oriented toward the discovery-to-delivery chain rather than a public feedback portal.

**Disclosure:** I'm the author. The contributing guidelines note self-submissions are assessed case-by-case, so please treat this as a suggestion rather than a request — happy to close it if you'd rather the list stayed to third-party recommendations, and equally happy to adjust the wording, section, or table fields.

Checklist against CONTRIBUTING.md:
- Matches the existing entry format (`####` heading, description, property table) and adds the corresponding Contents entry.
- Not paywalled — free and open source.
- No inappropriate, malicious, or deceitful links.
- Both links verified returning HTTP 200 (https://projectbook.dev and the GitHub repo).

I left out a screenshot to keep the diff text-only; 5 of the 18 existing tool entries have none. Glad to add one to `media/` if you'd prefer consistency with the illustrated entries.
