### PR TITLE
Add Klinky to Tools (Experimentation & A/B Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ By definition, a product manager is an individual who drives the product vision 
     - [Screeb](#screeb)
   - [OKRs & Outcome Tracking](#okrs--outcome-tracking)
     - [Tability](#tability)
+  - [Experimentation & A/B Testing](#experimentation--ab-testing)
+    - [Klinky](#klinky)
 - [Articles](#articles)
   - [Product Fundamentals & Philosophy](#product-fundamentals--philosophy)
   - [Product Development & Process](#product-development--process)
@@ -313,6 +315,22 @@ A lightweight OKR tracking tool that helps product teams stay focused on outcome
 | Cost       | Freemium (Paid plans from $35/mo)  |
 | Platform   | Web                                |
 | URL        | https://tability.io                |
+
+
+### Experimentation & A/B Testing
+Test changes with real traffic before committing to them. These tools help PMs run controlled rollouts and compare variants with data.
+
+
+#### Klinky
+An A/B testing link shortener that splits one link between two destinations at configurable weights. Useful for sending a controlled share of traffic to a new page, workflow, or offer and comparing variants with real-time click analytics, without changing the link already distributed.
+
+
+| Property   | Value                              |
+|------------|------------------------------------|
+| Developer  | [Klinky](https://klinky.io)        |
+| Cost       | Freemium                           |
+| Platform   | Web                                |
+| URL        | https://klinky.io                  |
 
 ## Articles
 


### PR DESCRIPTION
Adds [Klinky](https://klinky.io) to the Tools section under a new "Experimentation & A/B Testing" category.

Klinky is an A/B testing link shortener: one short link splits traffic between two destinations at configurable weights, with real-time click analytics. For PMs, this supports controlled rollouts of a new page, workflow, or offer — send a small share of traffic to the new version, compare variants with real data, then shift the weights, all without changing the link already distributed. Free tier available.

The entry follows the existing tool format (description + property table, no screenshot, matching the Tability entry). Disclosure: I am the founder of Klinky — submitting for case-by-case assessment per the contribution guidelines.