### PR TITLE
Add awesome-agentic-ai to Additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ Technical perspectives on product development and engineering practices.
 - [Stratechery by Ben Thompson](https://stratechery.com/) - Product and strategy insights from the industry.
 - [Mobbin](https://mobbin.design/) - Hand-picked collection of mobile app design patterns.
 - [Marketing for Engineers](https://github.com/goabstract/Marketing-for-Engineers) - A handy guide on growing marketing skills for folks with engineering backgrounds.
+- [awesome-agentic-ai](https://github.com/adriannoes/awesome-agentic-ai) - Free learning hub for PMs who ship with AI coding agents — spec-driven PRD and task templates, agent skills, notebooks, and papers for those re-learning the engineering side.
 
 ## License
 


### PR DESCRIPTION
Adds one link under **Additional resources**, next to Marketing for Engineers.

https://github.com/adriannoes/awesome-agentic-ai

I maintain this repo (MIT, public, no SaaS). CONTRIBUTING says self-promotion is frowned on, so a quick note on why I think it fits:

**What it is:** a learning hub, not a product. PM-facing templates and workflows for shipping with AI coding agents (Cursor, Claude Code, Codex), plus skills, notebooks, and papers.

**Why PMs:** the list already sits at the intersection of business, technology, and design. A growing slice of PMs are going deeper on the technical side — prototyping, reading code, pairing with agents — without becoming full-time engineers. This hub is built for that path.

**PM slice in the repo:**
- Spec-driven development guides (`no-vibe-coding.md`, PRD → tasks → execute)
- Copy-paste PM templates for PRDs, epics, and task breakdowns
- Spec-driven pipeline (Lean Inception → DDD → TDD) vendored with worked examples
- Industry reports useful for business cases and pitch decks

I am a PM re-learning software engineering myself; the repo reflects that use case. Happy to move it elsewhere or shorten the description if you prefer.