### PR TITLE
Add Product Manager OS to Additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ Technical perspectives on product development and engineering practices.
 - [Stratechery by Ben Thompson](https://stratechery.com/) - Product and strategy insights from the industry.
 - [Mobbin](https://mobbin.design/) - Hand-picked collection of mobile app design patterns.
 - [Marketing for Engineers](https://github.com/goabstract/Marketing-for-Engineers) - A handy guide on growing marketing skills for folks with engineering backgrounds.
+- [Product Manager OS](https://github.com/RizwanZafaris/product-manager-OS) - Open MIT repository for running a product from discovery to sunset: lifecycle templates with review gates, product management framework cards, and AI prompts and skills that also work without any AI.
 
 ## License
 


### PR DESCRIPTION
Adds [Product Manager OS](https://github.com/RizwanZafaris/product-manager-OS) to the Additional resources section, following the existing entry format there (alongside Marketing for Engineers, which is a similar repo-shaped resource).

**Disclosure: I am the author of this repository**, so per your contribution guidelines I am submitting it for case-by-case assessment rather than claiming neutrality.

What it is: an MIT-licensed repository for running a product end to end. It contains lifecycle templates (discovery documents, PRD, FRD, roadmaps, risk and decision registers, testing and launch readiness) each with an exit gate, framework summary cards for the standard PM canon with named attribution, and prompt and skill files for AI-assisted work that degrade gracefully: every template works with a plain text editor and no AI at all.

It is free, has no paywall, no sign-up, no commercial tier, and collects nothing. Links verified working. Happy to adjust placement, wording, or withdraw if it does not meet the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)