### PR TITLE
Add AI usage policy and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,12 @@
 
 ## Relationship to the resource
 
+<!-- We close pull requests that add the author's own work unless it meets the three conditions in the Self-promotion section of CONTRIBUTING.md. Employer, client, and agency relationships count as affiliation. -->
+
 - [ ] I have no affiliation with this resource
 - [ ] I am the author, maintainer, or otherwise affiliated (describe):
+  - The resource has existed since (month and year):
+  - Evidence that people unconnected to me use or recommend it (links):
 
 ## AI disclosure
 
@@ -20,5 +24,6 @@
 
 - [ ] I have read the [contributing guidelines](../CONTRIBUTING.md) and the [AI Usage Policy](../AI_POLICY.md)
 - [ ] I have used or read the resource I am adding
-- [ ] The entry follows the existing list format and is in the right section
+- [ ] The entry follows the existing list format and fits an existing section
+- [ ] I did not add a new section or category for this entry
 - [ ] The link works and the content is not paywalled

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,5 +23,5 @@ Required by the [AI Usage Policy](https://github.com/dend/awesome-product-manage
 
 - [ ] I have read the [contributing guidelines](https://github.com/dend/awesome-product-management/blob/master/CONTRIBUTING.md) and the [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md)
 - [ ] I have used or read the resource I am adding
-- [ ] The entry follows the existing list format and fits an existing section; I did not add a new section
+- [ ] The entry follows the existing list format and fits an existing section, and I did not add a new section
 - [ ] The link works, and articles are readable without payment or signup

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## What are you adding or changing?
+
+<!-- Name the resource and the section. In one or two sentences, in your own words, say why a product manager would find it genuinely useful. -->
+
+## Relationship to the resource
+
+- [ ] I have no affiliation with this resource
+- [ ] I am the author, maintainer, or otherwise affiliated (describe):
+
+## AI disclosure
+
+<!-- Required by the AI Usage Policy (AI_POLICY.md). Pull requests without this section filled in will be closed. -->
+
+- [ ] No AI tools were used in this contribution
+- [ ] AI tools were used. Tool(s):
+  - What they were used for:
+  - How much of the contribution is AI-generated:
+
+## Checklist
+
+- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md) and the [AI Usage Policy](../AI_POLICY.md)
+- [ ] I have personally used or read the resource I am adding
+- [ ] The entry follows the existing list format and is in the right section
+- [ ] The link works and the content is not paywalled

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,29 @@
 ## What are you adding or changing?
 
-<!-- Name the resource and the section. In one or two sentences, in your own words, say why a product manager would find it useful. -->
+<!-- Name the resource and the section. In one or two sentences, in your own words, say why a product manager would find it useful, and how you came to use it. -->
 
 ## Relationship to the resource
 
-See the [self-promotion rules](https://github.com/dend/awesome-product-management/blob/master/CONTRIBUTING.md#self-promotion). Employer, co-founder, investor, client, agency, family, and paid-promotion relationships count as affiliation, and so does being asked to submit.
+You are connected to a resource if you own, work on, or profit from it, if you are family, a partner, a friend, or a colleague of the people behind it, or if someone connected to it asked you to add it or offered you something for doing so. See the [self-promotion rules](https://github.com/dend/awesome-product-management/blob/master/CONTRIBUTING.md#self-promotion).
 
-- [ ] I have no affiliation with this resource, and no one connected to it asked me to submit it
-- [ ] I am affiliated (describe):
+- [ ] I have no connection to this resource, and no one connected to it asked me to submit it
+- [ ] I am connected to it (describe):
   - Public in its current form since (month and year), with a Wayback Machine link:
-  - Unsolicited coverage by people unconnected to me (links):
+  - Coverage by people unconnected to me who chose to cover it (links):
 
 ## AI disclosure
 
-Required by the [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md). I close pull requests that leave this blank. Spellcheck, grammar checkers, and translation of your own words do not count.
+The [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md) requires this section. If you leave it blank, I will ask you to fill it in before review. Spellcheck, grammar checkers, and machine translation of your own words do not count.
 
 - [ ] No AI assistant drafted or rewrote any of this
 - [ ] An AI assistant drafted or rewrote part of this. Tool:
   - Which parts the AI produced and which parts I wrote by hand:
+- [ ] An AI assistant helped in another way, such as suggesting a section or checking a sentence. Describe:
 
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](https://github.com/dend/awesome-product-management/blob/master/CONTRIBUTING.md) and the [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md)
+- [ ] I have read the parts of the [contributing guidelines](https://github.com/dend/awesome-product-management/blob/master/CONTRIBUTING.md) that apply to me
 - [ ] I have used or read the resource I am adding
-- [ ] The entry follows the existing list format and fits an existing section, and I did not add a new section
+- [ ] The resource is about product management, or is a tool product managers use
+- [ ] The entry copies the format of an existing entry in an existing section
 - [ ] The link works, and articles are readable without payment or signup

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## What are you adding or changing?
 
-<!-- Name the resource and the section. In one or two sentences, in your own words, say why a product manager would find it genuinely useful. -->
+<!-- Name the resource and the section. In one or two sentences, in your own words, say why a product manager would find it useful. -->
 
 ## Relationship to the resource
 
@@ -9,16 +9,16 @@
 
 ## AI disclosure
 
-<!-- Required by the AI Usage Policy (AI_POLICY.md). Pull requests without this section filled in will be closed. -->
+<!-- The AI Usage Policy (AI_POLICY.md) requires this section. We close pull requests that leave it blank. -->
 
-- [ ] No AI tools were used in this contribution
-- [ ] AI tools were used. Tool(s):
-  - What they were used for:
+- [ ] I did not use AI tools for this contribution
+- [ ] I used AI tools. Tool(s):
+  - What I used them for:
   - How much of the contribution is AI-generated:
 
 ## Checklist
 
 - [ ] I have read the [contributing guidelines](../CONTRIBUTING.md) and the [AI Usage Policy](../AI_POLICY.md)
-- [ ] I have personally used or read the resource I am adding
+- [ ] I have used or read the resource I am adding
 - [ ] The entry follows the existing list format and is in the right section
 - [ ] The link works and the content is not paywalled

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,26 +4,24 @@
 
 ## Relationship to the resource
 
-<!-- We close pull requests that add the author's own work unless it meets the three conditions in the Self-promotion section of CONTRIBUTING.md. Employer, client, and agency relationships count as affiliation. -->
+See the [self-promotion rules](https://github.com/dend/awesome-product-management/blob/master/CONTRIBUTING.md#self-promotion). Employer, co-founder, investor, client, agency, family, and paid-promotion relationships count as affiliation, and so does being asked to submit.
 
-- [ ] I have no affiliation with this resource
-- [ ] I am the author, maintainer, or otherwise affiliated (describe):
-  - The resource has existed since (month and year):
-  - Evidence that people unconnected to me use or recommend it (links):
+- [ ] I have no affiliation with this resource, and no one connected to it asked me to submit it
+- [ ] I am affiliated (describe):
+  - Public in its current form since (month and year), with a Wayback Machine link:
+  - Unsolicited coverage by people unconnected to me (links):
 
 ## AI disclosure
 
-<!-- The AI Usage Policy (AI_POLICY.md) requires this section. We close pull requests that leave it blank. -->
+Required by the [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md). We close pull requests that leave this blank. Spellcheck, grammar checkers, and translation of your own words do not count.
 
-- [ ] I did not use AI tools for this contribution
-- [ ] I used AI tools. Tool(s):
-  - What I used them for:
-  - How much of the contribution is AI-generated:
+- [ ] No AI assistant drafted or rewrote any of this
+- [ ] An AI assistant drafted or rewrote part of this. Tool:
+  - Which parts the AI produced and which parts I wrote by hand:
 
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md) and the [AI Usage Policy](../AI_POLICY.md)
+- [ ] I have read the [contributing guidelines](https://github.com/dend/awesome-product-management/blob/master/CONTRIBUTING.md) and the [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md)
 - [ ] I have used or read the resource I am adding
-- [ ] The entry follows the existing list format and fits an existing section
-- [ ] I did not add a new section or category for this entry
-- [ ] The link works and the content is not paywalled
+- [ ] The entry follows the existing list format and fits an existing section; I did not add a new section
+- [ ] The link works, and articles are readable without payment or signup

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ See the [self-promotion rules](https://github.com/dend/awesome-product-managemen
 
 ## AI disclosure
 
-Required by the [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md). We close pull requests that leave this blank. Spellcheck, grammar checkers, and translation of your own words do not count.
+Required by the [AI Usage Policy](https://github.com/dend/awesome-product-management/blob/master/AI_POLICY.md). I close pull requests that leave this blank. Spellcheck, grammar checkers, and translation of your own words do not count.
 
 - [ ] No AI assistant drafted or rewrote any of this
 - [ ] An AI assistant drafted or rewrote part of this. Tool:

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,9 +1,10 @@
 # AI Usage Policy
 
 > This policy is inspired by [Ghostty's AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).
+>
+> [Den](https://den.dev) maintains this list alone, so "I" in this policy means Den.
 
-You may use AI tools when contributing to this list. Den maintains this list
-alone, so "I" throughout this document means Den. This policy applies to
+You may use AI tools when contributing to this list. This policy applies to
 external contributions. I follow the same disclosure and media rules for entries
 I add myself, and I use AI as I see fit for review and triage.
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -7,37 +7,34 @@ exist to keep the list high-quality and to respect the time of human reviewers.
 
 ## Disclosure
 
-All AI usage **must** be disclosed. In your pull request description, you must
-include:
+You **must** disclose all AI usage. In your pull request description, include:
 
 1. **Which tool(s)** you used (e.g., Claude Code, Copilot, Cursor, ChatGPT).
-2. **What you used it for** — specify which parts of the entry, description, or
-   pull request text were AI-assisted versus written by hand.
+2. **What you used it for**. Name which parts of the entry, description, or
+   pull request text the AI touched and which parts you wrote by hand.
 3. **How much** of the contribution is AI-generated (e.g., "AI drafted the
    description, I rewrote it and verified the link").
 
-Undisclosed AI usage that is discovered after the fact will be treated as a
-policy violation.
+If we discover undisclosed AI usage after the fact, we treat it as a policy
+violation.
 
 ## You Must Understand Your Changes
 
 AI can help you write a description, but you are responsible for every line you
-submit. You must have actually used or read the resource you are adding, and you
-must be able to explain why it belongs on this list and in the section you chose
-— without the AI tool. If you cannot, the contribution is not ready. Maintainers
-may ask you to explain any part of your submission, and inability to do so is
-grounds for closing the PR.
+submit. You must have used or read the resource you are adding, and you must be
+able to explain why it belongs on this list and in the section you chose, without
+the AI tool. If you cannot, the contribution is not ready. Maintainers may ask you
+to explain any part of your submission. If you cannot answer, we close the PR.
 
 ## Review AI-Generated Text
 
-Pull request descriptions, issues, and entry text written with AI assistance
-must be reviewed and edited by a human before posting. Remove boilerplate
-filler, marketing language, unnecessary verbosity, and irrelevant details. Keep
-it concise and useful.
+A human must review and edit any pull request description, issue, or entry text
+written with AI assistance before posting it. Remove boilerplate filler, marketing
+language, and irrelevant details. Keep it short.
 
 ## No AI-Generated Media
 
-AI-generated images, art, audio, and video are not accepted. This includes tool
+We do not accept AI-generated images, art, audio, or video. This includes tool
 screenshots placed in `media/`. This policy covers text only.
 
 ## Low-Effort Contributions
@@ -49,28 +46,26 @@ Examples include:
 - Adding your own product, repository, or article with a pitch written by an AI
 - Drive-by PRs that "fix" formatting or reorder entries without being asked
 - Bulk additions with no clear purpose or explanation
-- Issues or comments that are obviously AI-generated walls of text
+- Issues or comments that are AI-generated walls of text
 
-Every contribution should demonstrate that the author has put genuine thought and
-effort into it. If it looks like you spent more time prompting an AI than
-evaluating the resource, it will be closed.
+Your contribution should show that you thought about the resource and put effort
+into the entry. If it looks like you spent more time prompting an AI than
+evaluating the resource, we close it.
 
 ## Maintainer Discretion
 
 The maintainers reserve the right to close any contribution that looks or reads
-like unreviewed AI output, regardless of whether AI usage was disclosed and
-regardless of whether it technically satisfies the rest of these guidelines.
-This is a judgment call and it is not up for debate in the pull request. If a
-contribution is closed on these grounds, the correct response is to rewrite it
-in your own words with your own reasoning, not to argue that the AI did a good
-job.
+like unreviewed AI output, whether or not you disclosed AI usage and whether or
+not it satisfies the rest of these guidelines. This is a judgment call, and we
+will not debate it in the pull request. If we close your contribution on these
+grounds, rewrite it in your own words with your own reasoning and open a new one.
 
 ## Enforcement
 
-Any violation of this policy will result in the contribution being closed and
-the contributor being **permanently blocked** from the project. There are no
-warnings. A public record of blocked contributors may be maintained and shared
-with other projects to help identify repeat offenders.
+If you violate this policy, we close the contribution and **block you from the
+project for good**. There are no warnings. We may keep a public record of blocked
+contributors and share it with other projects to help them identify repeat
+offenders.
 
 ## Maintainers
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,7 +1,8 @@
 # AI Usage Policy
 
 > This policy is inspired by [Ghostty's AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).
->
+
+> [!NOTE]
 > [Den](https://den.dev) maintains this list alone, so "I" in this policy means Den.
 
 You may use AI tools when contributing to this list. This policy applies to

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,68 @@
+# AI Usage Policy
+
+> This policy is inspired by [Ghostty's AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).
+
+We welcome the use of AI tools when contributing to this list. These guidelines
+exist to keep the list high-quality and to respect the time of human reviewers.
+
+## Disclosure
+
+All AI usage **must** be disclosed. In your pull request description, you must
+include:
+
+1. **Which tool(s)** you used (e.g., Claude Code, Copilot, Cursor, ChatGPT).
+2. **What you used it for** — specify which parts of the entry, description, or
+   pull request text were AI-assisted versus written by hand.
+3. **How much** of the contribution is AI-generated (e.g., "AI drafted the
+   description, I rewrote it and verified the link").
+
+Undisclosed AI usage that is discovered after the fact will be treated as a
+policy violation.
+
+## You Must Understand Your Changes
+
+AI can help you write a description, but you are responsible for every line you
+submit. You must have actually used or read the resource you are adding, and you
+must be able to explain why it belongs on this list and in the section you chose
+— without the AI tool. If you cannot, the contribution is not ready. Maintainers
+may ask you to explain any part of your submission, and inability to do so is
+grounds for closing the PR.
+
+## Review AI-Generated Text
+
+Pull request descriptions, issues, and entry text written with AI assistance
+must be reviewed and edited by a human before posting. Remove boilerplate
+filler, marketing language, unnecessary verbosity, and irrelevant details. Keep
+it concise and useful.
+
+## No AI-Generated Media
+
+AI-generated images, art, audio, and video are not accepted. This includes tool
+screenshots placed in `media/`. This policy covers text only.
+
+## Low-Effort Contributions
+
+We do not accept low-effort contributions of any kind, AI-assisted or otherwise.
+Examples include:
+
+- Unreviewed AI output submitted as-is ("slop")
+- Adding your own product, repository, or article with a pitch written by an AI
+- Drive-by PRs that "fix" formatting or reorder entries without being asked
+- Bulk additions with no clear purpose or explanation
+- Issues or comments that are obviously AI-generated walls of text
+
+Every contribution should demonstrate that the author has put genuine thought and
+effort into it. If it looks like you spent more time prompting an AI than
+evaluating the resource, it will be closed.
+
+## Enforcement
+
+Any violation of this policy will result in the contribution being closed and
+the contributor being **permanently blocked** from the project. There are no
+warnings. A public record of blocked contributors may be maintained and shared
+with other projects to help identify repeat offenders.
+
+## Maintainers
+
+These guidelines apply to external contributions. Project maintainers may use AI
+tools at their own discretion.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -19,18 +19,18 @@ In the pull request description, include:
 
 Spellcheck, grammar checkers, and machine translation of your own words do not
 count as AI assistance. If you are unsure whether something counts, disclose it.
-Disclosing too much has no cost.
+Over-disclosing costs you nothing with me.
 
-Disclosure protects you. I judge a disclosed AI-assisted pull request on the
-entry alone.
+Disclosure means I do not treat the AI use itself as a problem, and disclosed AI
+use never leads to a block. I still read the entry, and I may close it or ask
+you to tighten it.
 
 ## You Must Understand Your Changes
 
-You are responsible for every line you submit. Know the resource you are adding:
-you have read the book, listened to several episodes, or used the tool long
-enough to say what it is good for. Be ready to say in a sentence or two why it
-belongs in the section you chose, without help from the AI tool. I may ask. If
-you cannot answer, I close the pull request.
+You are responsible for every line you submit. Know the resource. Read the book,
+listen to several episodes, or use the tool long enough to say what it is good
+for. If I ask why the resource belongs where you put it, answer in your own
+words. That is the whole test. If you cannot answer, I close the pull request.
 
 ## Review AI-Generated Text
 
@@ -40,9 +40,9 @@ click. Keep it short.
 
 ## No AI-Generated Media
 
-You may use AI assistance for text only. I do not accept AI-generated or
-AI-edited images, audio, or video. Screenshots and GIFs in `media/` must be real
-captures of the tool.
+You may use AI assistance for text only. Images in `media/` must be real: a
+screenshot or capture of the tool, or the resource's own published artwork. I do
+not accept AI-generated or AI-edited images, audio, or video.
 
 ## Low-Effort Contributions
 
@@ -50,54 +50,54 @@ I close low-effort contributions without further review, AI-assisted or not.
 Examples:
 
 - Unreviewed AI output submitted as-is
-- A pitch for your own product written by an AI (see the
+- An advertisement for your own product written by an AI (see the
   [self-promotion rules](CONTRIBUTING.md#self-promotion))
 - Reordering entries or reformatting a section without opening an issue first
-- Bulk additions with no explanation
-- Issues or comments that are AI-generated walls of text
+- More than one new resource in a pull request
+- Issues or comments that are very long generated text
 
-Typo, broken-link, and broken-anchor fixes are welcome without an issue.
-
-Closure under this section is not a violation and I do not record it against
-you. Rewrite the contribution in your own words and open a new pull request.
+Typo, broken-link, and broken-anchor fixes are welcome without an issue, and you
+may batch them.
 
 ## Maintainer Discretion
 
-I may close any contribution that reads like unreviewed AI output, whether or
-not you disclosed AI usage and whether or not it meets the rest of these rules.
-This is a judgment call. I will say what looked off, and I will not debate it in
-the pull request thread. Closure on these grounds is not a violation.
+I may close any contribution that looks like generated text that no one edited,
+whether or not you disclosed AI use. This is a judgment I make. I will say which
+part looked generated, and I will not debate it in the pull request thread.
+Rewrite that part in your own words and open a new pull request.
 
 ## Enforcement
 
-This policy and the [contribution guidelines](CONTRIBUTING.md) have two
+This policy and the [contribution guidelines](CONTRIBUTING.md) have three
 outcomes.
 
-**I close** pull requests that fail the rules above or the self-promotion rules.
-You may rewrite and resubmit once. I do not record a closure against you.
+**I close** pull requests that fail the rules in either document. The closed
+pull request is the only record, and it does not count against you. Rewrite and
+resubmit. If I close the same resource twice in twelve months, whoever submits
+it, the resource is ineligible for a year.
 
-**I block** contributors from the project, with no warning, for any of the
-following:
+**I remove** an entry from the list when its page stops loading, or when the
+pull request that added it under this policy stated no affiliation and one
+applied. A resource removed for a hidden affiliation is ineligible for a year.
 
-- Denying an affiliation when asked, or hiding one I find later
-- Submitting a resource that does not exist, or a description that misstates
-  what the resource does
-- Resubmitting closed work without changes
-- Submitting on behalf of someone whose own pull request I closed
+**I block** a contributor for one of the following, and for nothing else:
 
-I remove any resource that reached the list through a hidden affiliation, and it
-stays ineligible.
+- Stating, in the template or in reply to my question, that you have no
+  connection to a resource you made, or that someone asked or paid you to
+  submit
+- Linking evidence that does not show what you claim: a link that does not
+  resolve to the named resource, or a Wayback Machine snapshot or coverage link
+  that does not support the statement it sits next to
+- Resubmitting a closed resource without addressing the reason I gave
 
-I keep blocks private. I do not publish or share lists of blocked contributors.
-
-## Appeals
-
-If you believe I closed or blocked you in error, open an issue titled "Appeal"
-within 30 days. Link the pull request and explain in a few sentences. I review
-each decision once and reply in the issue.
+There is no appeal process, so I block only for these acts, which I can check
+against the pull request itself, and never for a judgment about writing style.
+A GitHub block is visible to the person blocked and applies to every repository
+under my account. I do not publish or share a list of blocked contributors.
 
 ---
 
-Version 1.0, effective 5 September 2026. I change this policy by pull request to
-this repository. Changes apply to pull requests opened after I merge them.
-Questions: open an issue. Asking is not a violation.
+Version 1.0. This policy and the contribution guidelines apply to every pull
+request that is open on the day this version merges and to every pull request
+opened after it. I change this policy by pull request to this repository, and
+changes take effect the same way. Questions? Open an issue.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -55,6 +55,16 @@ Every contribution should demonstrate that the author has put genuine thought an
 effort into it. If it looks like you spent more time prompting an AI than
 evaluating the resource, it will be closed.
 
+## Maintainer Discretion
+
+The maintainers reserve the right to close any contribution that looks or reads
+like unreviewed AI output, regardless of whether AI usage was disclosed and
+regardless of whether it technically satisfies the rest of these guidelines.
+This is a judgment call and it is not up for debate in the pull request. If a
+contribution is closed on these grounds, the correct response is to rewrite it
+in your own words with your own reasoning, not to argue that the AI did a good
+job.
+
 ## Enforcement
 
 Any violation of this policy will result in the contribution being closed and

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -2,14 +2,14 @@
 
 > This policy is inspired by [Ghostty's AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).
 
-You may use AI tools when contributing to this list. This policy applies to
-external contributions. We, the maintainers, follow the same disclosure and
-media rules for entries we add ourselves, and we use AI as we see fit for review
-and triage.
+You may use AI tools when contributing to this list. Den maintains this list
+alone, so "I" throughout this document means Den. This policy applies to
+external contributions. I follow the same disclosure and media rules for entries
+I add myself, and I use AI as I see fit for review and triage.
 
 ## Disclosure
 
-Tell us when an AI assistant drafted or rewrote any part of your pull request.
+Tell me when an AI assistant drafted or rewrote any part of your pull request.
 In the pull request description, include:
 
 1. **Which tool(s)** you used, such as Claude Code, Copilot, Cursor, or ChatGPT.
@@ -19,7 +19,7 @@ Spellcheck, grammar checkers, and machine translation of your own words do not
 count as AI assistance. If you are unsure whether something counts, disclose it.
 Disclosing too much has no cost.
 
-Disclosure protects you. We judge a disclosed AI-assisted pull request on the
+Disclosure protects you. I judge a disclosed AI-assisted pull request on the
 entry alone.
 
 ## You Must Understand Your Changes
@@ -27,8 +27,8 @@ entry alone.
 You are responsible for every line you submit. Know the resource you are adding:
 you have read the book, listened to several episodes, or used the tool long
 enough to say what it is good for. Be ready to say in a sentence or two why it
-belongs in the section you chose, without help from the AI tool. We may ask. If
-you cannot answer, we close the pull request.
+belongs in the section you chose, without help from the AI tool. I may ask. If
+you cannot answer, I close the pull request.
 
 ## Review AI-Generated Text
 
@@ -38,13 +38,13 @@ click. Keep it short.
 
 ## No AI-Generated Media
 
-You may use AI assistance for text only. We do not accept AI-generated or
+You may use AI assistance for text only. I do not accept AI-generated or
 AI-edited images, audio, or video. Screenshots and GIFs in `media/` must be real
 captures of the tool.
 
 ## Low-Effort Contributions
 
-We close low-effort contributions without further review, AI-assisted or not.
+I close low-effort contributions without further review, AI-assisted or not.
 Examples:
 
 - Unreviewed AI output submitted as-is
@@ -56,48 +56,46 @@ Examples:
 
 Typo, broken-link, and broken-anchor fixes are welcome without an issue.
 
-Closure under this section is not a violation and we do not record it against
+Closure under this section is not a violation and I do not record it against
 you. Rewrite the contribution in your own words and open a new pull request.
 
 ## Maintainer Discretion
 
-We may close any contribution that reads like unreviewed AI output, whether or
+I may close any contribution that reads like unreviewed AI output, whether or
 not you disclosed AI usage and whether or not it meets the rest of these rules.
-This is a judgment call. We will say what looked off, and we will not debate it
-in the pull request thread. Closure on these grounds is not a violation.
+This is a judgment call. I will say what looked off, and I will not debate it in
+the pull request thread. Closure on these grounds is not a violation.
 
 ## Enforcement
 
 This policy and the [contribution guidelines](CONTRIBUTING.md) have two
 outcomes.
 
-**We close** pull requests that fail the rules above or the self-promotion
-rules. You may rewrite and resubmit once. We do not record a closure against
-you.
+**I close** pull requests that fail the rules above or the self-promotion rules.
+You may rewrite and resubmit once. I do not record a closure against you.
 
-**We block** contributors from the project, with no warning, for any of the
+**I block** contributors from the project, with no warning, for any of the
 following:
 
-- Denying an affiliation when asked, or hiding one we find later
+- Denying an affiliation when asked, or hiding one I find later
 - Submitting a resource that does not exist, or a description that misstates
   what the resource does
 - Resubmitting closed work without changes
-- Submitting on behalf of someone whose own pull request we closed
+- Submitting on behalf of someone whose own pull request I closed
 
-We remove any resource that reached the list through a hidden affiliation, and
-it stays ineligible.
+I remove any resource that reached the list through a hidden affiliation, and it
+stays ineligible.
 
-We keep blocks private. We do not publish or share lists of blocked
-contributors.
+I keep blocks private. I do not publish or share lists of blocked contributors.
 
 ## Appeals
 
-If you believe we closed or blocked you in error, open an issue titled "Appeal"
-within 30 days. Link the pull request and explain in a few sentences. We review
+If you believe I closed or blocked you in error, open an issue titled "Appeal"
+within 30 days. Link the pull request and explain in a few sentences. I review
 each decision once and reply in the issue.
 
 ---
 
-Version 1.0, effective 5 September 2026. We change this policy by pull request
-to this repository. Changes apply to pull requests opened after we merge them.
+Version 1.0, effective 5 September 2026. I change this policy by pull request to
+this repository. Changes apply to pull requests opened after I merge them.
 Questions: open an issue. Asking is not a violation.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -77,23 +77,24 @@ resubmit. If I close the same resource twice in twelve months, whoever submits
 it, the resource is ineligible for a year.
 
 **I remove** an entry from the list when its page stops loading, or when the
-pull request that added it under this policy stated no affiliation and one
-applied. A resource removed for a hidden affiliation is ineligible for a year.
+pull request that added it under this policy stated no connection and one
+existed. A resource removed for a hidden connection is ineligible for a year.
 
-**I block** a contributor for one of the following, and for nothing else:
+**I block** a contributor only for repeat behavior or blatant spam. A first
+offense of anything in these documents is a closure, not a block. Blocks are
+for:
 
-- Stating, in the template or in reply to my question, that you have no
-  connection to a resource you made, or that someone asked or paid you to
-  submit
-- Linking evidence that does not show what you claim: a link that does not
-  resolve to the named resource, or a Wayback Machine snapshot or coverage link
-  that does not support the statement it sits next to
-- Resubmitting a closed resource without addressing the reason I gave
+- Resubmitting the same resource a third time without addressing the reason I
+  gave for the earlier closures
+- Stating no connection to a resource, then doing it again with another
+  resource after I have corrected you once
+- Blatant spam: links to malicious or deceptive pages, link farms, or a burst of
+  unrelated pull requests or comments that exist to place links
 
-There is no appeal process, so I block only for these acts, which I can check
-against the pull request itself, and never for a judgment about writing style.
-A GitHub block is visible to the person blocked and applies to every repository
-under my account. I do not publish or share a list of blocked contributors.
+There is no appeal process, so I keep the bar here high and I do not block for
+a judgment about writing style or a single mistake. A GitHub block is visible
+to the person blocked and applies to every repository under my account. I do
+not publish or share a list of blocked contributors.
 
 ---
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -2,73 +2,102 @@
 
 > This policy is inspired by [Ghostty's AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).
 
-We welcome the use of AI tools when contributing to this list. These guidelines
-exist to keep the list high-quality and to respect the time of human reviewers.
+You may use AI tools when contributing to this list. This policy applies to
+external contributions. We, the maintainers, follow the same disclosure and
+media rules for entries we add ourselves, and we use AI as we see fit for review
+and triage.
 
 ## Disclosure
 
-You **must** disclose all AI usage. In your pull request description, include:
+Tell us when an AI assistant drafted or rewrote any part of your pull request.
+In the pull request description, include:
 
-1. **Which tool(s)** you used (e.g., Claude Code, Copilot, Cursor, ChatGPT).
-2. **What you used it for**. Name which parts of the entry, description, or
-   pull request text the AI touched and which parts you wrote by hand.
-3. **How much** of the contribution is AI-generated (e.g., "AI drafted the
-   description, I rewrote it and verified the link").
+1. **Which tool(s)** you used, such as Claude Code, Copilot, Cursor, or ChatGPT.
+2. **Which parts** the AI produced and which parts you wrote by hand.
 
-If we discover undisclosed AI usage after the fact, we treat it as a policy
-violation.
+Spellcheck, grammar checkers, and machine translation of your own words do not
+count as AI assistance. If you are unsure whether something counts, disclose it.
+Disclosing too much has no cost.
+
+Disclosure protects you. We judge a disclosed AI-assisted pull request on the
+entry alone.
 
 ## You Must Understand Your Changes
 
-AI can help you write a description, but you are responsible for every line you
-submit. You must have used or read the resource you are adding, and you must be
-able to explain why it belongs on this list and in the section you chose, without
-the AI tool. If you cannot, the contribution is not ready. Maintainers may ask you
-to explain any part of your submission. If you cannot answer, we close the PR.
+You are responsible for every line you submit. Know the resource you are adding:
+you have read the book, listened to several episodes, or used the tool long
+enough to say what it is good for. Be ready to say in a sentence or two why it
+belongs in the section you chose, without help from the AI tool. We may ask. If
+you cannot answer, we close the pull request.
 
 ## Review AI-Generated Text
 
-A human must review and edit any pull request description, issue, or entry text
-written with AI assistance before posting it. Remove boilerplate filler, marketing
-language, and irrelevant details. Keep it short.
+Read and edit any AI-assisted text before you post it. Cut boilerplate,
+marketing language, and detail that does not help a reader decide whether to
+click. Keep it short.
 
 ## No AI-Generated Media
 
-We do not accept AI-generated images, art, audio, or video. This includes tool
-screenshots placed in `media/`. This policy covers text only.
+You may use AI assistance for text only. We do not accept AI-generated or
+AI-edited images, audio, or video. Screenshots and GIFs in `media/` must be real
+captures of the tool.
 
 ## Low-Effort Contributions
 
-We do not accept low-effort contributions of any kind, AI-assisted or otherwise.
-Examples include:
+We close low-effort contributions without further review, AI-assisted or not.
+Examples:
 
-- Unreviewed AI output submitted as-is ("slop")
-- Adding your own product, repository, or article with a pitch written by an AI
-  (see the [self-promotion rules](CONTRIBUTING.md#self-promotion))
-- Drive-by PRs that "fix" formatting or reorder entries without being asked
-- Bulk additions with no clear purpose or explanation
+- Unreviewed AI output submitted as-is
+- A pitch for your own product written by an AI (see the
+  [self-promotion rules](CONTRIBUTING.md#self-promotion))
+- Reordering entries or reformatting a section without opening an issue first
+- Bulk additions with no explanation
 - Issues or comments that are AI-generated walls of text
 
-Your contribution should show that you thought about the resource and put effort
-into the entry. If it looks like you spent more time prompting an AI than
-evaluating the resource, we close it.
+Typo, broken-link, and broken-anchor fixes are welcome without an issue.
+
+Closure under this section is not a violation and we do not record it against
+you. Rewrite the contribution in your own words and open a new pull request.
 
 ## Maintainer Discretion
 
-The maintainers reserve the right to close any contribution that looks or reads
-like unreviewed AI output, whether or not you disclosed AI usage and whether or
-not it satisfies the rest of these guidelines. This is a judgment call, and we
-will not debate it in the pull request. If we close your contribution on these
-grounds, rewrite it in your own words with your own reasoning and open a new one.
+We may close any contribution that reads like unreviewed AI output, whether or
+not you disclosed AI usage and whether or not it meets the rest of these rules.
+This is a judgment call. We will say what looked off, and we will not debate it
+in the pull request thread. Closure on these grounds is not a violation.
 
 ## Enforcement
 
-If you violate this policy, we close the contribution and **block you from the
-project for good**. There are no warnings. We may keep a public record of blocked
-contributors and share it with other projects to help them identify repeat
-offenders.
+This policy and the [contribution guidelines](CONTRIBUTING.md) have two
+outcomes.
 
-## Maintainers
+**We close** pull requests that fail the rules above or the self-promotion
+rules. You may rewrite and resubmit once. We do not record a closure against
+you.
 
-These guidelines apply to external contributions. Project maintainers may use AI
-tools at their own discretion.
+**We block** contributors from the project, with no warning, for any of the
+following:
+
+- Denying an affiliation when asked, or hiding one we find later
+- Submitting a resource that does not exist, or a description that misstates
+  what the resource does
+- Resubmitting closed work without changes
+- Submitting on behalf of someone whose own pull request we closed
+
+We remove any resource that reached the list through a hidden affiliation, and
+it stays ineligible.
+
+We keep blocks private. We do not publish or share lists of blocked
+contributors.
+
+## Appeals
+
+If you believe we closed or blocked you in error, open an issue titled "Appeal"
+within 30 days. Link the pull request and explain in a few sentences. We review
+each decision once and reply in the issue.
+
+---
+
+Version 1.0, effective 5 September 2026. We change this policy by pull request
+to this repository. Changes apply to pull requests opened after we merge them.
+Questions: open an issue. Asking is not a violation.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -44,6 +44,7 @@ Examples include:
 
 - Unreviewed AI output submitted as-is ("slop")
 - Adding your own product, repository, or article with a pitch written by an AI
+  (see the [self-promotion rules](CONTRIBUTING.md#self-promotion))
 - Drive-by PRs that "fix" formatting or reorder entries without being asked
 - Bulk additions with no clear purpose or explanation
 - Issues or comments that are AI-generated walls of text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Contribution Guidelines
 
+> [!NOTE]
 > [Den](https://den.dev) maintains this list alone, so "I" in these guidelines means Den.
 
 This project has a [Contributor Code of Conduct](code-of-conduct.md). By participating you agree to its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
 
+This project also has an [AI Usage Policy](AI_POLICY.md). Any use of AI tools in a contribution must be disclosed in the pull request, and undisclosed or low-effort AI-generated submissions will be closed and the contributor blocked. Read it before opening a pull request.
+
 ## Adding items to the list
 
 If you have something awesome to contribute to the list, simply [fork the repository](https://help.github.com/en/articles/fork-a-repo), make your changes, and [submit a pull request](https://help.github.com/en/articles/creating-a-pull-request).
@@ -14,3 +16,4 @@ Some general guidelines to consider:
 - This list is not for self-promotion - posting links to your own articles is generally frowned upon (_we can assess those PRs on a case-by-case basis_).
 - The list is not an advertising surface. It's not about pitching the latest productivity SaaS product, but rather about tools that are _genuinely_ helpful for product/program managers.
 - Make sure that the links you submit are working correctly. Pages that are not loading/resulting in errors will be removed.
+- Disclose any AI assistance per the [AI Usage Policy](AI_POLICY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 
 This project has a [Contributor Code of Conduct](code-of-conduct.md). By participating you agree to its terms.
 
-If you found a resource you have no connection to and want to add it, you are the contributor I want. Fill in the pull request template, tick "no affiliation", and skip the section on connected resources below.
+If you found a resource you have no connection to and want to add it, you are the contributor I want. Fill in the pull request template, tick "no connection", and skip the section on connected resources below.
 
 If an AI assistant drafted or rewrote any part of your pull request, say so. The [AI Usage Policy](AI_POLICY.md) explains what to include.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
 
-This project also has an [AI Usage Policy](AI_POLICY.md). Any use of AI tools in a contribution must be disclosed in the pull request, and undisclosed or low-effort AI-generated submissions will be closed and the contributor blocked. Read it before opening a pull request.
+This project also has an [AI Usage Policy](AI_POLICY.md). Any use of AI tools in a contribution must be disclosed in the pull request. The maintainers reserve the right to close anything that reads like unreviewed AI output, and undisclosed or low-effort AI-generated submissions will get the contributor blocked. Read it before opening a pull request.
 
 ## Adding items to the list
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,11 @@
 
 This project has a [Contributor Code of Conduct](code-of-conduct.md). By participating you agree to its terms.
 
-It also has an [AI Usage Policy](AI_POLICY.md). Tell us in your pull request when an AI assistant drafted or rewrote any part of it. We may close anything that reads like unreviewed AI output. Read the policy before you open a pull request.
+It also has an [AI Usage Policy](AI_POLICY.md). Tell me in your pull request when an AI assistant drafted or rewrote any part of it. I may close anything that reads like unreviewed AI output. Read the policy before you open a pull request.
 
-If you found a resource you have no connection to and want to add it, you are the contributor we want. Fill in the pull request template, tick "no affiliation", and skip the self-promotion section below.
+Den maintains this list alone, so "I" in these guidelines means Den.
+
+If you found a resource you have no connection to and want to add it, you are the contributor I want. Fill in the pull request template, tick "no affiliation", and skip the self-promotion section below.
 
 ## Adding items to the list
 
@@ -17,12 +19,12 @@ Rules for every pull request:
 - Do not link to resources that are inappropriate, malicious, or deceitful.
 - Articles and posts must be readable without payment or signup. Books and courses may cost money; link to a page where a reader can buy or download them.
 - Do not submit your own work. See [Self-promotion](#self-promotion).
-- Check that your links load. We remove entries whose pages error.
+- Check that your links load. I remove entries whose pages error.
 - Disclose AI assistance per the [AI Usage Policy](AI_POLICY.md).
 
 ## Self-promotion
 
-We close pull requests that add the author's own product, repository, newsletter, podcast, course, or article. This is the default, and it applies whether the resource is free, open source, or paid.
+I close pull requests that add the author's own product, repository, newsletter, podcast, course, or article. This is the default, and it applies whether the resource is free, open source, or paid.
 
 You are affiliated with a resource if any of these is true:
 
@@ -33,17 +35,17 @@ You are affiliated with a resource if any of these is true:
 
 Sending an occasional patch to an open source project does not make you affiliated. Working for a company does not make you affiliated with everything it publishes, unless someone asked you to submit it. If you are unsure, say so in the pull request. Disclosing an uncertain relationship is not a violation.
 
-These rules cover any change that adds, replaces, or redirects a link, including link fixes, description edits, and items inside a multi-entry pull request. They also cover content hosted on a vendor's domain or gated behind signup, which we treat as that vendor's product.
+These rules cover any change that adds, replaces, or redirects a link, including link fixes, description edits, and items inside a multi-entry pull request. They also cover content hosted on a vendor's domain or gated behind signup, which I treat as that vendor's product.
 
-We make an exception when the resource has an audience that does not depend on you. Show all three in the pull request:
+I make an exception when the resource has an audience that does not depend on you. Show all three in the pull request:
 
 - The resource has been public in its current form for at least six months. Link a [Wayback Machine](https://web.archive.org/) snapshot from six or more months ago.
 - People with no connection to you recommend it. Link to unsolicited, uncompensated coverage. A book, newsletter, podcast, or community that is on this list is the strongest evidence. Reviews on your own site, launch platforms, customer testimonials, and sponsored placements do not count.
-- An existing section fits it. We do not add a section or category to hold one entry.
+- An existing section fits it. I do not add a section or category to hold one entry.
 
 If you cannot show all three, do not open the pull request.
 
-State your relationship to the resource in the pull request. This applies to pull requests opened on or after 5 September 2026. If we find an affiliation you did not disclose, we remove the entry. If you denied the affiliation when asked, we block you. See [Enforcement](AI_POLICY.md#enforcement).
+State your relationship to the resource in the pull request. This applies to pull requests opened on or after 5 September 2026. If I find an affiliation you did not disclose, I remove the entry. If you denied the affiliation when asked, I block you. See [Enforcement](AI_POLICY.md#enforcement).
 
 These rules apply to every kind of resource. A GitHub repository, prompt pack, agent skill collection, template, or "awesome" list is a product for the purposes of this section, and its author is its vendor.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
 
-This project also has an [AI Usage Policy](AI_POLICY.md). Any use of AI tools in a contribution must be disclosed in the pull request. The maintainers reserve the right to close anything that reads like unreviewed AI output, and undisclosed or low-effort AI-generated submissions will get the contributor blocked. Read it before opening a pull request.
+This project also has an [AI Usage Policy](AI_POLICY.md). You must disclose any use of AI tools in your pull request. The maintainers reserve the right to close anything that reads like unreviewed AI output, and we block contributors who submit undisclosed or low-effort AI-generated work. Read the policy before opening a pull request.
 
 ## Adding items to the list
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,4 @@ If you cannot show all three, do not open the pull request. Ask someone who uses
 
 You must state your relationship to the resource in the pull request. If we find an undisclosed affiliation later, we remove the entry and block the contributor, per the [AI Usage Policy](AI_POLICY.md#enforcement).
 
-Prompt packs, agent skill collections, template repositories, and "awesome" lists that launched in the past six months are self-promotion when their author submits them. We close those without review.
+These rules apply to every kind of resource. A GitHub repository, prompt pack, agent skill collection, template, or "awesome" list is a product for the purposes of this section, and its author is its vendor. Free and open source do not exempt it from the conditions above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ If you found a resource you have no connection to and want to add it, you are th
 Rules for every pull request:
 
 - One entry per pull request.
-- Match the format of the section you are adding to. Books and articles look like `- [Title](url) - By Author.` Tools use the table format under Tools; copy an existing tool entry.
+- Match the format of the section you are adding to. Books and articles look like `- [Title](url) - By Author.` Tools use the table format under Tools. Copy an existing tool entry.
 - Do not link to resources that are inappropriate, malicious, or deceitful.
-- Articles and posts must be readable without payment or signup. Books and courses may cost money; link to a page where a reader can buy or download them.
+- Articles and posts must be readable without payment or signup. Books and courses may cost money. Link to a page where a reader can buy or download them.
 - Do not submit your own work. See [Self-promotion](#self-promotion).
 - Check that your links load. I remove entries whose pages error.
 - Disclose AI assistance per the [AI Usage Policy](AI_POLICY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contribution Guidelines
 
+> [Den](https://den.dev) maintains this list alone, so "I" in these guidelines means Den.
+
 This project has a [Contributor Code of Conduct](code-of-conduct.md). By participating you agree to its terms.
 
 It also has an [AI Usage Policy](AI_POLICY.md). Tell me in your pull request when an AI assistant drafted or rewrote any part of it. I may close anything that reads like unreviewed AI output. Read the policy before you open a pull request.
-
-Den maintains this list alone, so "I" in these guidelines means Den.
 
 If you found a resource you have no connection to and want to add it, you are the contributor I want. Fill in the pull request template, tick "no affiliation", and skip the self-promotion section below.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,52 @@
 # Contribution Guidelines
 
-Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
+This project has a [Contributor Code of Conduct](code-of-conduct.md). By participating you agree to its terms.
 
-This project also has an [AI Usage Policy](AI_POLICY.md). You must disclose any use of AI tools in your pull request. The maintainers reserve the right to close anything that reads like unreviewed AI output, and we block contributors who submit undisclosed or low-effort AI-generated work. Read the policy before opening a pull request.
+It also has an [AI Usage Policy](AI_POLICY.md). Tell us in your pull request when an AI assistant drafted or rewrote any part of it. We may close anything that reads like unreviewed AI output. Read the policy before you open a pull request.
+
+If you found a resource you have no connection to and want to add it, you are the contributor we want. Fill in the pull request template, tick "no affiliation", and skip the self-promotion section below.
 
 ## Adding items to the list
 
-If you have something awesome to contribute to the list, simply [fork the repository](https://help.github.com/en/articles/fork-a-repo), make your changes, and [submit a pull request](https://help.github.com/en/articles/creating-a-pull-request).
+[Fork the repository](https://help.github.com/en/articles/fork-a-repo), make your change, and [open a pull request](https://help.github.com/en/articles/creating-a-pull-request).
 
-Some general guidelines to consider:
+Rules for every pull request:
 
-- Please ensure your pull request adheres to the existing list format.
-- Do not include links to resources that can be considered inappropriate, malicious or deceitful.
-- Do not include links to pay-walled content.
-- Do not submit your own work. See [Self-promotion](#self-promotion) below.
-- The list is not an advertising surface. Entries are tools and resources that product and program managers already rely on, not pitches for the latest SaaS product.
-- Make sure that the links you submit are working correctly. Pages that are not loading/resulting in errors will be removed.
-- Disclose any AI assistance per the [AI Usage Policy](AI_POLICY.md).
+- One entry per pull request.
+- Match the format of the section you are adding to. Books and articles look like `- [Title](url) - By Author.` Tools use the table format under Tools; copy an existing tool entry.
+- Do not link to resources that are inappropriate, malicious, or deceitful.
+- Articles and posts must be readable without payment or signup. Books and courses may cost money; link to a page where a reader can buy or download them.
+- Do not submit your own work. See [Self-promotion](#self-promotion).
+- Check that your links load. We remove entries whose pages error.
+- Disclose AI assistance per the [AI Usage Policy](AI_POLICY.md).
 
 ## Self-promotion
 
-We close pull requests that add the author's own product, repository, newsletter, podcast, course, or article. This is the default and it applies whether the resource is free, open source, or paid.
+We close pull requests that add the author's own product, repository, newsletter, podcast, course, or article. This is the default, and it applies whether the resource is free, open source, or paid.
 
-"Your own" includes anything you built, maintain, or are paid to promote. Submitting on behalf of your employer, your co-founder, a client, or an agency counts the same as submitting your own work.
+You are affiliated with a resource if any of these is true:
 
-We make an exception when the resource has an audience that does not depend on you. To qualify, show all of the following in the pull request:
+- You own, operate, wrote, or maintain it, or you are on the team that does.
+- You or your employer earn money from it or from the organization that publishes it. This includes equity, referral commissions, and free or discounted access.
+- You have a personal or family relationship with the people behind it.
+- Someone connected to it asked, referred, or rewarded you to submit it.
 
-- The resource has existed for at least six months.
-- People with no connection to you use it, write about it, or recommend it. Link to that evidence.
-- An existing section fits it. We do not add a new section or category to hold one entry.
+Sending an occasional patch to an open source project does not make you affiliated. Working for a company does not make you affiliated with everything it publishes, unless someone asked you to submit it. If you are unsure, say so in the pull request. Disclosing an uncertain relationship is not a violation.
 
-If you cannot show all three, do not open the pull request. Ask someone who uses the resource and has no stake in it to submit it instead.
+These rules cover any change that adds, replaces, or redirects a link, including link fixes, description edits, and items inside a multi-entry pull request. They also cover content hosted on a vendor's domain or gated behind signup, which we treat as that vendor's product.
 
-You must state your relationship to the resource in the pull request. If we find an undisclosed affiliation later, we remove the entry and block the contributor, per the [AI Usage Policy](AI_POLICY.md#enforcement).
+We make an exception when the resource has an audience that does not depend on you. Show all three in the pull request:
+
+- The resource has been public in its current form for at least six months. Link a [Wayback Machine](https://web.archive.org/) snapshot from six or more months ago.
+- People with no connection to you recommend it. Link to unsolicited, uncompensated coverage. A book, newsletter, podcast, or community that is on this list is the strongest evidence. Reviews on your own site, launch platforms, customer testimonials, and sponsored placements do not count.
+- An existing section fits it. We do not add a section or category to hold one entry.
+
+If you cannot show all three, do not open the pull request.
+
+State your relationship to the resource in the pull request. This applies to pull requests opened on or after 5 September 2026. If we find an affiliation you did not disclose, we remove the entry. If you denied the affiliation when asked, we block you. See [Enforcement](AI_POLICY.md#enforcement).
 
 These rules apply to every kind of resource. A GitHub repository, prompt pack, agent skill collection, template, or "awesome" list is a product for the purposes of this section, and its author is its vendor.
+
+## Questions
+
+Open an issue. Asking is not a violation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We close pull requests that add the author's own product, repository, newsletter
 
 We make an exception when the resource has an audience that does not depend on you. To qualify, show all of the following in the pull request:
 
-- The resource has existed for at least a year.
+- The resource has existed for at least six months.
 - People with no connection to you use it, write about it, or recommend it. Link to that evidence.
 - An existing section fits it. We do not add a new section or category to hold one entry.
 
@@ -34,4 +34,4 @@ If you cannot show all three, do not open the pull request. Ask someone who uses
 
 You must state your relationship to the resource in the pull request. If we find an undisclosed affiliation later, we remove the entry and block the contributor, per the [AI Usage Policy](AI_POLICY.md#enforcement).
 
-Prompt packs, agent skill collections, template repositories, and "awesome" lists that launched in the past year are self-promotion when their author submits them. We close those without review.
+Prompt packs, agent skill collections, template repositories, and "awesome" lists that launched in the past six months are self-promotion when their author submits them. We close those without review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@
 
 This project has a [Contributor Code of Conduct](code-of-conduct.md). By participating you agree to its terms.
 
-It also has an [AI Usage Policy](AI_POLICY.md). Tell me in your pull request when an AI assistant drafted or rewrote any part of it. I may close anything that reads like unreviewed AI output. Read the policy before you open a pull request.
+If you found a resource you have no connection to and want to add it, you are the contributor I want. Fill in the pull request template, tick "no affiliation", and skip the section on connected resources below.
 
-If you found a resource you have no connection to and want to add it, you are the contributor I want. Fill in the pull request template, tick "no affiliation", and skip the self-promotion section below.
+If an AI assistant drafted or rewrote any part of your pull request, say so. The [AI Usage Policy](AI_POLICY.md) explains what to include.
 
 ## Adding items to the list
 
@@ -15,41 +15,49 @@ If you found a resource you have no connection to and want to add it, you are th
 
 Rules for every pull request:
 
-- One entry per pull request.
-- Match the format of the section you are adding to. Books and articles look like `- [Title](url) - By Author.` Tools use the table format under Tools. Copy an existing tool entry.
+- The resource must be about product management, or be a tool product managers use in that role.
+- Use or read the resource before you submit it.
+- One new resource per pull request. You may batch fixes to existing links, anchors, or typos.
+- Copy an existing entry from the section you are adding to, including any `media/` capture, and match its format.
+- Add to an existing section. Open an issue before proposing a new one.
+- Write the description for a reader deciding whether to click, not as an advertisement.
 - Do not link to resources that are inappropriate, malicious, or deceitful.
 - Articles and posts must be readable without payment or signup. Books and courses may cost money. Link to a page where a reader can buy or download them.
-- Do not submit your own work. See [Self-promotion](#self-promotion).
-- Check that your links load. I remove entries whose pages error.
+- Do not submit your own work. See the next section if you are connected to the resource.
+- Check that your links load. I remove entries whose pages stop loading.
 - Disclose AI assistance per the [AI Usage Policy](AI_POLICY.md).
 
 ## Self-promotion
 
-I close pull requests that add the author's own product, repository, newsletter, podcast, course, or article. This is the default, and it applies whether the resource is free, open source, or paid.
+Skip this section if you have no connection to the resource.
 
-You are affiliated with a resource if any of these is true:
+I close pull requests that add the author's own product, repository, prompt pack, skill collection, template, "awesome" list, newsletter, podcast, course, or article. This is the default, and it applies whether the resource is free, open source, or paid.
+
+You are connected to a resource if any of these is true:
 
 - You own, operate, wrote, or maintain it, or you are on the team that does.
-- You or your employer earn money from it or from the organization that publishes it. This includes equity, referral commissions, and free or discounted access.
-- You have a personal or family relationship with the people behind it.
-- Someone connected to it asked, referred, or rewarded you to submit it.
+- You or your employer earn money from it or from the organization that publishes it. This includes salary, equity, referral commissions, and free or discounted access.
+- You are family, a partner, a friend, or a current or former colleague of the people who made it.
+- Someone connected to it asked you to add it here, or offered you something for doing so.
 
-Sending an occasional patch to an open source project does not make you affiliated. Working for a company does not make you affiliated with everything it publishes, unless someone asked you to submit it. If you are unsure, say so in the pull request. Disclosing an uncertain relationship is not a violation.
+Sending an occasional small contribution to an open source project does not connect you to it. Following the author or exchanging a comment with them does not either. Hearing about a resource from a colleague or the author's own newsletter is not being asked to add it. I do not ask about your relationships. I act on what is public or what you tell me. If you are unsure, say so in the pull request, and I will treat that as disclosure.
 
-These rules cover any change that adds, replaces, or redirects a link, including link fixes, description edits, and items inside a multi-entry pull request. They also cover content hosted on a vendor's domain or gated behind signup, which I treat as that vendor's product.
+If a pull request adds a commercial product or service and does not say how the submitter relates to it and how they came to use it, I close it. I do not investigate.
 
-I make an exception when the resource has an audience that does not depend on you. Show all three in the pull request:
+These rules cover any change that adds, replaces, or redirects a link, including link fixes and description edits. They also cover content hosted on a vendor's domain or gated behind signup, which I treat as that vendor's product.
 
-- The resource has been public in its current form for at least six months. Link a [Wayback Machine](https://web.archive.org/) snapshot from six or more months ago.
-- People with no connection to you recommend it. Link to unsolicited, uncompensated coverage. A book, newsletter, podcast, or community that is on this list is the strongest evidence. Reviews on your own site, launch platforms, customer testimonials, and sponsored placements do not count.
+I make an exception when the resource is about product management and has an audience that does not depend on you. Show all three in the pull request:
+
+- The resource has been public in its current form for at least six months on the day you open the pull request. Link a [Wayback Machine](https://web.archive.org/) snapshot from six or more months ago. I compare it to the live page, and it must show the same name and the same core function.
+- People with no connection to you recommend it, and they chose to. Link to coverage where the editor, host, or author picked the resource unprompted. Guest posts, community threads, appearances you pitched, launch platforms, customer testimonials, reviews on your own site, and sponsored placements do not count. An appearance on my own podcast is not evidence.
 - An existing section fits it. I do not add a section or category to hold one entry.
 
 If you cannot show all three, do not open the pull request.
 
-State your relationship to the resource in the pull request. This applies to pull requests opened on or after 5 September 2026. If I find an affiliation you did not disclose, I remove the entry. If you denied the affiliation when asked, I block you. See [Enforcement](AI_POLICY.md#enforcement).
+State your relationship to the resource in the pull request. An issue asking whether a specific resource you are connected to would qualify is a pull request in disguise, and I close it. Consequences for a hidden connection are in the [Enforcement section](AI_POLICY.md#enforcement) of the AI Usage Policy.
 
-These rules apply to every kind of resource. A GitHub repository, prompt pack, agent skill collection, template, or "awesome" list is a product for the purposes of this section, and its author is its vendor.
+Entries added before this policy stay on the list. These rules apply to pull requests, not to the existing list, and I follow them for anything I add from now on.
 
 ## Questions
 
-Open an issue. Asking is not a violation.
+Open an issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,25 @@ Some general guidelines to consider:
 - Please ensure your pull request adheres to the existing list format.
 - Do not include links to resources that can be considered inappropriate, malicious or deceitful.
 - Do not include links to pay-walled content.
-- This list is not for self-promotion - posting links to your own articles is generally frowned upon (_we can assess those PRs on a case-by-case basis_).
-- The list is not an advertising surface. It's not about pitching the latest productivity SaaS product, but rather about tools that are _genuinely_ helpful for product/program managers.
+- Do not submit your own work. See [Self-promotion](#self-promotion) below.
+- The list is not an advertising surface. Entries are tools and resources that product and program managers already rely on, not pitches for the latest SaaS product.
 - Make sure that the links you submit are working correctly. Pages that are not loading/resulting in errors will be removed.
 - Disclose any AI assistance per the [AI Usage Policy](AI_POLICY.md).
+
+## Self-promotion
+
+We close pull requests that add the author's own product, repository, newsletter, podcast, course, or article. This is the default and it applies whether the resource is free, open source, or paid.
+
+"Your own" includes anything you built, maintain, or are paid to promote. Submitting on behalf of your employer, your co-founder, a client, or an agency counts the same as submitting your own work.
+
+We make an exception when the resource has an audience that does not depend on you. To qualify, show all of the following in the pull request:
+
+- The resource has existed for at least a year.
+- People with no connection to you use it, write about it, or recommend it. Link to that evidence.
+- An existing section fits it. We do not add a new section or category to hold one entry.
+
+If you cannot show all three, do not open the pull request. Ask someone who uses the resource and has no stake in it to submit it instead.
+
+You must state your relationship to the resource in the pull request. If we find an undisclosed affiliation later, we remove the entry and block the contributor, per the [AI Usage Policy](AI_POLICY.md#enforcement).
+
+Prompt packs, agent skill collections, template repositories, and "awesome" lists that launched in the past year are self-promotion when their author submits them. We close those without review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,4 @@ If you cannot show all three, do not open the pull request. Ask someone who uses
 
 You must state your relationship to the resource in the pull request. If we find an undisclosed affiliation later, we remove the entry and block the contributor, per the [AI Usage Policy](AI_POLICY.md#enforcement).
 
-These rules apply to every kind of resource. A GitHub repository, prompt pack, agent skill collection, template, or "awesome" list is a product for the purposes of this section, and its author is its vendor. Free and open source do not exempt it from the conditions above.
+These rules apply to every kind of resource. A GitHub repository, prompt pack, agent skill collection, template, or "awesome" list is a product for the purposes of this section, and its author is its vendor.


### PR DESCRIPTION
## Summary

Adds an AI usage policy, a default-closed self-promotion rule, and a pull request template. Written in first person, since Den maintains the list alone.

**AI_POLICY.md**
- Contributors disclose when an AI assistant drafted or rewrote part of a pull request. Spellcheck, grammar checkers, and machine translation are carved out. Disclosed AI use never leads to a block.
- Three outcomes. I close pull requests that fail the rules, and the closed PR is the only record. I remove entries whose pages stop loading or that were added under a hidden connection. I block only for repeat behavior or blatant spam: a third resubmission of the same resource without addressing the reason, a second false no-connection statement after a correction, or malicious links, link farms, and bursts of link-placing pull requests. A first offense of anything is a closure. There is no appeal process, so the block bar stays high and nothing style-based can trigger one.
- A resource closed twice in twelve months is ineligible for a year, whoever submits it. No public or shared blocklist.
- Applies to every pull request open on the day it merges and every one opened after.

**CONTRIBUTING.md**
- New rules for every pull request: the resource must be about product management, the submitter must have used or read it, one new resource per PR with link fixes batchable, copy an existing entry's format, add to an existing section, write for a reader rather than as an advertisement. The paywall rule now applies to articles only.
- Self-promotion is closed by default. Connection is defined by four tests: ownership or team membership, money including salary and equity and referral income and free access, family or partner or friend or colleague, and being asked or rewarded to submit. Casual follows and comments do not count, and I do not ask about relationships.
- Commercial products must say how the submitter relates to them and came to use them, or I close without investigating.
- The exception requires six months public with a Wayback Machine snapshot I compare to the live page, coverage the editor or host chose unprompted (guest posts, pitched appearances, launch platforms, and my own podcast do not count), and an existing section.
- Entries added before this policy stay. The rules apply to pull requests, and I follow them for anything I add from now on.

**.github/PULL_REQUEST_TEMPLATE.md**
- Connection and AI disclosure sections that mirror the rules, with a third AI option for minor help. Absolute links so they resolve in the rendered PR body.

## Review

Two rounds of adversarial review from five angles each: awesome-list maintainer, growth marketer hunting loopholes, first-time contributor, open source governance, and technical editor. The second round also applied the policy to all 22 open PRs. All 22 close on a quoted sentence under this text.

## Note

The template's absolute links point at `blob/master/`, so the Lychee link check on this PR will 404 on them until merge. They resolve after.